### PR TITLE
Fix entity creation

### DIFF
--- a/generators/entity/prompts.js
+++ b/generators/entity/prompts.js
@@ -477,7 +477,7 @@ function askForField(done) {
             message: 'What is the name of your field?'
         },
         {
-            when: response => response.fieldAdd === true && (skipServer || databaseType === 'sql' || databaseType === 'mongodb' || this.databaseType === 'couchbase'),
+            when: response => response.fieldAdd === true && (skipServer || databaseType === 'sql' || databaseType === 'mongodb' || databaseType === 'couchbase'),
             type: 'list',
             name: 'fieldType',
             message: 'What is the type of your field?',


### PR DESCRIPTION
Remove unwanted 'this.' in prompt commands (unable to create any entity with field because each field type is not defined)