### PR TITLE
Upgrade jhipster-core to v1.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "glob": "7.1.2",
     "html-wiring": "1.2.0",
     "insight": "0.8.4",
-    "jhipster-core": "1.3.7",
+    "jhipster-core": "1.4.0",
     "js-yaml": "3.10.0",
     "lodash": "4.17.4",
     "meow": "3.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1425,9 +1425,9 @@ isurl@^1.0.0-alpha5:
     has-to-string-tag-x "^1.2.0"
     is-object "^1.0.1"
 
-jhipster-core@1.3.7:
-  version "1.3.7"
-  resolved "https://registry.yarnpkg.com/jhipster-core/-/jhipster-core-1.3.7.tgz#5cc5fcb8ed556f67aab74ab18caf2a0c028d32af"
+jhipster-core@1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/jhipster-core/-/jhipster-core-1.4.0.tgz#8e812cf5d7eed8997d95bf73c0bdd3535f0d0cdb"
   dependencies:
     lodash "4.17.4"
 


### PR DESCRIPTION
In order to get the JDL studio working with Couchbase. See comment by @MathieuAA: https://github.com/jhipster/jhipster-core/pull/164#issuecomment-339310019.