### PR TITLE
Fix Couchbase container version as same as used in application

### DIFF
--- a/generators/server/templates/src/test/java/package/config/_DatabaseTestConfiguration.java
+++ b/generators/server/templates/src/test/java/package/config/_DatabaseTestConfiguration.java
@@ -79,7 +79,7 @@ public class DatabaseTestConfiguration extends AbstractCouchbaseConfiguration {
         if (couchbaseContainer != null) {
             return couchbaseContainer;
         }
-        couchbaseContainer = new CouchbaseContainer()
+        couchbaseContainer = new CouchbaseContainer("<%= DOCKER_COUCHBASE %>")
             .withNewBucket(DefaultBucketSettings.builder()
                 .name(name)
                 .type(BucketType.COUCHBASE)


### PR DESCRIPTION
Same version as it is used in development (see custom Couchbase Dockerfile).
